### PR TITLE
Set properties

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,6 +45,18 @@ lsp-mode client leveraging microsoft's [[https://github.com/Microsoft/python-lan
    #+END_SRC
 
 For developement, you might find it useful to run =cask install=.
+
+* Configuration
+*** Server settings
+    If you'd like to provide configuration to the language server, you can set ~lsp-python-ms-server-settings~ before
+    initialization.  This is a plist with ~:[setting name] -> value~, and it's equivalent to using ~settings.json~ in MS Visual Studio.
+    For example
+
+    #+begin_src elisp
+    (setq lsp-python-ms-server-settings
+       '(:python.analysis.logLevel "info"
+         :python.analysis.errors ("undefined-variable")))
+    #+end_src
 * Credit
 
 All credit to [[https://cpbotha.net][cpbotha]] on [[https://vxlabs.com/2018/11/19/configuring-emacs-lsp-mode-and-microsofts-visual-studio-code-python-language-server/][vxlabs]]!  This just tidies and packages his

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -74,6 +74,9 @@ should be as they are (or would appear) in sys.path.  Paths will
 be prepended to the search path, and so will shadow duplicate
 names in search paths returned by the interpreter.")
 
+(defvar lsp-python-ms-server-setings nil
+  "Settings for the python language server.  This should be a plist of :<setting name> -> value")
+
 (defun lsp-python-ms--find-server-executable ()
   "Get path to the python language server executable."
   (cond
@@ -199,6 +202,10 @@ other handlers. "
   :server-id 'mspyls
   :priority 1
   :initialization-options 'lsp-python-ms--extra-init-params
+  :initialized-fn (lambda (workspace)
+                    (when lsp-python-ms-server-setings
+                      (with-lsp-workspace workspace
+                        (lsp--set-configuration `(:python ,lsp-python-ms-server-setings)))))
   :notification-handlers (lsp-ht ("python/languageServerStarted" 'lsp-python-ms--language-server-started-callback)
                                  ("telemetry/event" 'ignore)
                                  ;; TODO handle this more gracefully


### PR DESCRIPTION
Many options can be set on the MS language server with `settings.json` in MS Visual Studio.  The language server supports updating those same settings with `workspace/didChangeConfiguration`, and `lsp-mode` already has a method to send that event.  This just hooks into that framework.