### PR TITLE
Bumped down to python 0.24.4 since the required emacs is 24.4

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -3,7 +3,7 @@
 ;; Author: Charl Botha
 ;; Maintainer: Andrew Christianson
 ;; Version: 0.1.0
-;; Package-Requires: ((cl-lib "0.6.1") (lsp-mode "6.0") (python "0.26.1") (json "1.4") (emacs "24.4"))
+;; Package-Requires: ((cl-lib "0.6.1") (lsp-mode "6.0") (python "0.24.4") (json "1.4") (emacs "24.4"))
 ;; Homepage: https://github.com/andrew-christianson/lsp-python-ms
 ;; Keywords: languages tools
 


### PR DESCRIPTION
In my machine (windows 10 - 2019 May version), `(require 'lsp-python-ms)` broken down with macro expansion error

> Eager macro-expansion failure: (invalid-function (lambda (name doc &optional &rest skel) "Define a `python-mode' auxiliary skeleton using NAME DOC and SKEL.
The skeleton will be bound to python-skeleton-NAME." (let* ((name (symbol-name name)) (function-name (intern (concat "python-skeleton--" name))) (msg (format "Add '%s' clause? " name))) (if (not skel) (progn (setq skel (cons (quote <) (cons (format "%s:" name) (quote (n n > _ n))))))) (cons (quote define-skeleton) (cons function-name (cons (or doc (format "Auxiliary skeleton for %s statement." name)) (cons nil (cons (cons (quote unless) (cons (list (quote y-or-n-p) msg) (quote ((signal (quote quit) t))))) skel))))))))
Eager macro-expansion failure: (invalid-function (lambda (name doc &optional &rest skel) "Define a `python-mode' auxiliary skeleton using NAME DOC and SKEL.
The skeleton will be bound to python-skeleton-NAME." (let* ((name (symbol-name name)) (function-name (intern (concat "python-skeleton--" name))) (msg (format "Add '%s' clause? " name))) (if (not skel) (progn (setq skel (cons (quote <) (cons (format "%s:" name) (quote (n n > _ n))))))) (cons (quote define-skeleton) (cons function-name (cons (or doc (format "Auxiliary skeleton for %s statement." name)) (cons nil (cons (cons (quote unless) (cons (list (quote y-or-n-p) msg) (quote ((signal (quote quit) t))))) skel))))))))
File mode specification error: (invalid-function (lambda (name doc &optional &rest skel) Define a `python-mode' auxiliary skeleton using NAME DOC and SKEL.
The skeleton will be bound to python-skeleton-NAME. (let* ((name (symbol-name name)) (function-name (intern (concat python-skeleton-- name))) (msg (format Add '%s' clause?  name))) (if (not skel) (progn (setq skel (cons (quote <) (cons (format %s: name) (quote (n n > _ n))))))) (cons (quote define-skeleton) (cons function-name (cons (or doc (format Auxiliary skeleton for %s statement. name)) (cons nil (cons (cons (quote unless) (cons (list (quote y-or-n-p) msg) (quote ((signal (quote quit) t))))) skel))))))))

It seems that there're problem with python package (that available on `marmalade` and `gnu`).
Actually in the code we're not using `python` package specific  function anywhere, so it should be safe to remove that dependency and make me happy.


Also, if you're using Windows, I'm created a pre-built binary for Python language server [here](https://github.com/kiennq/python-ls-ms-releases).
You can install it using [scoop](https://scoop.sh/) and with my [bucket](https://github.com/kiennq/scoop-misc)