### PR TITLE
use executable-find to check executable exists

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -121,7 +121,7 @@ stable, beta or daily.")
 With prefix, FORCED to redownload the server."
   (interactive "P")
   (unless (and (not forced)
-               (file-exists-p lsp-python-ms-executable))
+               (executable-find lsp-python-ms-executable))
     (let ((temp-file (make-temp-file "mspyls" nil ".zip"))
           (unzip-script (cond ((executable-find "powershell")
                                "powershell -noprofile -noninteractive \
@@ -254,10 +254,10 @@ other handlers. "
 (defun lsp-python-ms--command-string ()
   "Return the command to start the server."
   ;; Try to download server if it doesn't exists
-  (unless (file-exists-p lsp-python-ms-executable)
+  (unless (executable-find lsp-python-ms-executable)
     (lsp-python-ms-setup))
 
-  (if (file-exists-p lsp-python-ms-executable)
+  (if (executable-find lsp-python-ms-executable)
       lsp-python-ms-executable
     (error (concat "Cannot find Microsoft Python Language Server executable! It's expected to be "
                    lsp-python-ms-executable))))


### PR DESCRIPTION
Currently `lsp-python-ms-executable` must be specified in an absolute path. This is undesirable when my executable is already in the PATH.