### PR TITLE
Avoid issues with shadowing the system json module

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -160,7 +160,7 @@ After stopping or killing the process, retry to update."
 The WORKSPACE-ROOT will be prepended to the list of python search
 paths and then the entire list will be json-encoded."
   (let ((python (executable-find lsp-python-executable-cmd))
-        (init "from __future__ import print_function; import sys; import json;")
+        (init "from __future__ import print_function; import sys; sys.path = list(filter(lambda p: p != '', sys.path)); import json;")
         (ver "print(\"%s.%s\" % (sys.version_info[0], sys.version_info[1]));")
         (sp (concat "sys.path.insert(0, '" workspace-root "'); print(json.dumps(sys.path))")))
     (with-temp-buffer


### PR DESCRIPTION
This patch removes the empty string "" entry from sys.path when detecting python versions to prevent the issue of the system json module getting shadowed by a local json module.

We all know that shadowing system modules in python is a bad idea, but unfortunately it happens. The code that lsp-python-ms runs to detect the python version and sys.path breaks if you have a local json module in the same directory as the file you are editing.

I've written a brief Dockerfile to recreate the issue and demonstrate the fix. Tested on python 2.7 and 3.7, I assume it will work for all versions in between but thats easy enough to check by tweaking the python version number at the top of the Dockerfile:

```
FROM python:3.7
WORKDIR /root

# This line creates the problem by shadowing the system json library
RUN touch json.py

# What lsp-python-ms would run currently for a project in the folder /root
CMD ["python", "-c", "from __future__ import print_function; import sys; import json;print(\"%s.%s\" % (sys.version_info[0], sys.version_info[1]));sys.path.insert(0, '/root/'); print(json.dumps(sys.path))"]

# My proposed fix. We're not using any files in the current directory and we already add the absolute path to the sys.path at the end, so theres no need for empty string "" to be in the sys.path
CMD ["python", "-c", "from __future__ import print_function; import sys; sys.path = list(filter(lambda p: p != '', sys.path)); import json;print(\"%s.%s\" % (sys.version_info[0], sys.version_info[1]));sys.path.insert(0, '/root/'); print(json.dumps(sys.path))"]
```

To recreate the issue, comment out the final `CMD` and run
```
docker build -t pythonissue . && docker run --rm -i -t pythonissue
```

to see it fixed, do the same but with the final `CMD` no longer commented out.