### PR TITLE
Fix incorrect provide statement

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -317,6 +317,6 @@ other handlers. "
                     (with-lsp-workspace workspace
                       (lsp--set-configuration (lsp-configuration-section "python"))))))
 
-(provide 'lsp-mspyls)
+(provide 'lsp-python-ms)
 
 ;;; lsp-python-ms.el ends here


### PR DESCRIPTION
It needs to match the file name to keep `require` happy.  Looks like this was collateral damage from the recent renaming/refactor.