### PR TITLE
Get PYTHONPATH from .env file.

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -29,20 +29,23 @@
 ;; from https://vxlabs.com/2018/11/19/configuring-emacs-lsp-mode-and-microsofts-visual-studio-code-python-language-server/
 
 ;;; Code:
+(require 'cl)
 
 (defvar lsp-python-ms-dir nil
-  "Path to langeuage server directory containing
-Microsoft.Python.LanguageServer.dll")
+  "Path to langeuage server directory containing Microsoft.Python.LanguageServer.dll")
 
 (defvar lsp-python-ms-dotnet nil
   "Path to dotnet executable.")
+
+(defvar lsp-python-ms-executable nil
+  "Path to Microsoft.Python.LanguageServer.exe")
 
 ;; it's crucial that we send the correct Python version to MS PYLS,
 ;; else it returns no docs in many cases furthermore, we send the
 ;; current Python's (can be virtualenv) sys.path as searchPaths
 
 (defun lsp-python-ms--get-python-ver-and-syspath (workspace-root)
-  "return list with pyver-string and json-encoded list of python
+  "Return list with pyver-string and json-encoded list of python
 search paths."
   (let ((python (executable-find python-shell-interpreter))
         (init "from __future__ import print_function; import sys; import json;")
@@ -55,24 +58,23 @@ search paths."
 ;; I based most of this on the vs.code implementation:
 ;; https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/languageServer/languageServer.ts#L219
 ;; (it still took quite a while to get right, but here we are!)
-(defun lsp-python-ms--extra-init-params (workspace)
-  (destructuring-bind (pyver pysyspath)
-      (lsp-python-ms--get-python-ver-and-syspath (lsp--workspace-root workspace))
-    `(:interpreter
-      (:properties (
-                    :InterpreterPath ,(executable-find python-shell-interpreter)
-                    ;; this database dir will be created if required
-                    :DatabasePath ,(expand-file-name (concat lsp-python-ms-dir "db/"))
-                    :Version ,pyver))
-      ;; preferredFormat "markdown" or "plaintext"
-      ;; experiment to find what works best -- over here mostly plaintext
-      :displayOptions (
-                       :preferredFormat "plaintext"
-                       :trimDocumentationLines :json-false
-                       :maxDocumentationLineLength 0
-                       :trimDocumentationText :json-false
-                       :maxDocumentationTextLength 0)
-      :searchPaths ,(json-read-from-string pysyspath))))
+(defun lsp-python-ms--extra-init-params (&optional workspace)
+  (let ((workspace-root (if workspace (lsp--workspace-root workspace) (pwd))))
+    (destructuring-bind (pyver pysyspath)
+      (lsp-python-ms--get-python-ver-and-syspath workspace-root)
+      `(:interpreter
+        (:properties (:InterpreterPath ,(executable-find python-shell-interpreter)
+                      ;; this database dir will be created if required
+                      :DatabasePath ,(expand-file-name (concat lsp-python-ms-dir "db/"))
+                      :Version ,pyver))
+        ;; preferredFormat "markdown" or "plaintext"
+        ;; experiment to find what works best -- over here mostly plaintext
+        :displayOptions (:preferredFormat "plaintext"
+                         :trimDocumentationLines :json-false
+                         :maxDocumentationLineLength 0
+                         :trimDocumentationText :json-false
+                         :maxDocumentationTextLength 0)
+        :searchPaths ,(json-read-from-string pysyspath)))))
 
 (defun lsp-python-ms--client-initialized (client)
   "Callback for client initialized."
@@ -100,16 +102,35 @@ search paths."
     (replace-regexp-in-string rx " " str)))
 
 (setq lsp-render-markdown-markup-content #'lsp-python-ms--filter-nbsp)
-(advice-add 'lsp-ui-doc--extract
-            :filter-return #'lsp-python-ms--filter-nbsp)
+(advice-add 'lsp-ui-doc--extract :filter-return #'lsp-python-ms--filter-nbsp)
 
-(lsp-define-stdio-client
- lsp-python "python"
- #'lsp-python-ms--workspace-root
- `(,(lsp-python-ms--find-dotnet) ,(concat lsp-python-ms-dir "Microsoft.Python.LanguageServer.dll"))
- :extra-init-params #'lsp-python-ms--extra-init-params
- :initialize #'lsp-python-ms--client-initialized)
+(defun lsp-python-ms--command-string ()
+  "Return the command that starts the server."
+  (if lsp-python-ms-executable
+      lsp-python-ms-executable
+    (list (lsp-python-ms--find-dotnet)
+          (concat lsp-python-ms-dir "Microsoft.Python.LanguageServer.dll"))))
 
+;;; Old lsp-mode
+(unless (fboundp 'lsp-register-client)
+  (lsp-define-stdio-client
+   lsp-python "python"
+   #'lsp-python-ms--workspace-root
+   nil
+   :command-fn 'lsp-python-ms--command-string
+   :extra-init-params #'lsp-python-ms--extra-init-params
+   :initialize #'lsp-python-ms--client-initialized))
+
+;;; New lsp-mode
+(when (fboundp 'lsp-register-client)
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection 'lsp-python-ms--command-string)
+    :major-modes '(python-mode)
+    :server-id 'mspyls
+    :initialization-options 'lsp-python-ms--extra-init-params
+    :notification-handlers (lsp-ht ("python/languageServerStarted" 'lsp-python-ms--language-server-started))
+    )))
 
 (provide 'lsp-python-ms)
 

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -284,17 +284,17 @@ directory"
 (defun lsp-python-ms--parse-dot-env (root &optional envvar)
   "Set environment variable (default PYTHONPATH) from .env file if this file exists in the project root."
   (let* ((envvar (or envvar "PYTHONPATH"))
-	 (file (concat (file-name-as-directory root) ".env"))
-	 (rx (concat "^[:blank:]*" envvar "[:blank:]*=[:blank:]*"))
-	 val)
+         (file (concat (file-name-as-directory root) ".env"))
+         (rx (concat "^[:blank:]*" envvar "[:blank:]*=[:blank:]*"))
+         val)
     (when (file-exists-p file)
       (with-temp-buffer
-	(insert-file-contents file)
-	(keep-lines rx (point-min) (point-max))
-	(when (string-match (concat rx "\\(.*\\)") (buffer-string))
-	  (setq val (match-string 1 (buffer-string)))
-	  (when (not (string-empty-p val))
-	    (setenv envvar val)))))))
+        (insert-file-contents file)
+        (keep-lines rx (point-min) (point-max))
+        (when (string-match (concat rx "\\(.*\\)") (buffer-string))
+          (setq val (match-string 1 (buffer-string)))
+          (unless (string-empty-p val)
+            (setenv envvar val)))))))
 
 (defun lsp-python-ms--language-server-started-callback (workspace _params)
   "Handle the python/languageServerStarted message.

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -207,9 +207,6 @@ After stopping or killing the process, retry to update."
   (interactive)
   (lsp-python-ms-setup t))
 
-(defvar lsp-python-ms-executable nil
-  "Path to Microsoft.Python.LanguageServer.exe")
-
 ;; it's crucial that we send the correct Python version to MS PYLS,
 ;; else it returns no docs in many cases furthermore, we send the
 ;; current Python's (can be virtualenv) sys.path as searchPaths
@@ -252,6 +249,7 @@ lsp-workspace-root function that finds the current buffer's
 workspace root.  If nothing works, default to the current file's
 directory"
   (let ((workspace-root (if workspace (lsp--workspace-root workspace) (lsp-python-ms--workspace-root))))
+    (lsp-python-ms--parse-dot-env workspace-root)
     (cl-destructuring-bind (pyver _pysyspath pyintpath)
         (lsp-python-ms--get-python-ver-and-syspath workspace-root)
       `(:interpreter
@@ -282,6 +280,21 @@ directory"
       (setq rx (concat rx "\\|\r")))
     (when str
       (replace-regexp-in-string rx " " str))))
+
+(defun lsp-python-ms--parse-dot-env (root &optional envvar)
+  "Set environment variable (default PYTHONPATH) from .env file if this file exists in the project root."
+  (let* ((envvar (or envvar "PYTHONPATH"))
+	 (file (concat (file-name-as-directory root) ".env"))
+	 (rx (concat "^[:blank:]*" envvar "[:blank:]*=[:blank:]*"))
+	 val)
+    (when (file-exists-p file)
+      (with-temp-buffer
+	(insert-file-contents file)
+	(keep-lines rx (point-min) (point-max))
+	(when (string-match (concat rx "\\(.*\\)") (buffer-string))
+	  (setq val (match-string 1 (buffer-string)))
+	  (when (not (string-empty-p val))
+	    (setenv envvar val)))))))
 
 (defun lsp-python-ms--language-server-started-callback (workspace _params)
   "Handle the python/languageServerStarted message.


### PR DESCRIPTION
I had a problem with unresolved references when I was running lsp-python-ms from a subdirectory of the project root. A possible solution to this problem is to put a ".env" file in the project root and define the environment variable "PYTHONPATH" there. This PR adds functionality that parses the ".env" file for PYTHONPATH definitions and sets the environment variable prior to starting the language server.