### PR TITLE
Remove toplevel sexp and wrap it with *-initialize function

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,16 +7,19 @@ Include ~lsp-python-ms~ in the configuration file:
 (require 'lsp-python-ms)
 (setq lsp-python-ms-auto-install-server t)
 (add-hook 'python-mode-hook #'lsp) ; or lsp-deferred
+(lsp-python-ms-initialize)
 #+END_SRC
 
 A minimal ~use-package~ initialization might be:
 #+BEGIN_SRC elisp
+  (use-package lsp
+    :hook (python-mode . lsp))             ; or lsp-deferred
+
   (use-package lsp-python-ms
+    :after python
     :ensure t
     :init (setq lsp-python-ms-auto-install-server t)
-    :hook (python-mode . (lambda ()
-                            (require 'lsp-python-ms)
-                            (lsp))))  ; or lsp-deferred
+    :config (lsp-python-ms-initialize))
 #+END_SRC
 
 ** Installing the executable
@@ -38,14 +41,15 @@ Note that ~python37Packages.python-language-server~ refers to Palintir's languag
 Finally, ensure that Emacs knows where to find the executable by setting ~lsp-python-ms-executable~.
 
 #+begin_src elisp
-  (use-package lsp-python-ms
-    :ensure t
-    :hook (python-mode . (lambda ()
-                           (require 'lsp-python-ms)
-                           (lsp)))
-    :init
-    (setq lsp-python-ms-executable (executable-find "python-language-server")))
+  (use-package lsp
+    :hook (python-mode . lsp))             ; or lsp-deferred
 
+  (use-package lsp-python-ms
+    :after python
+    :ensure t
+    :init (setq lsp-python-ms-auto-install-server t)
+    :custom (lsp-python-ms-executable (executable-find "python-language-server"))
+    :config (lsp-python-ms-initialize))
 #+end_src
 
 *** Most other distros

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -379,20 +379,6 @@ directory"
 WORKSPACE is just used for logging and _PARAMS is unused."
    (lsp--info "Microsoft Python language server started"))
 
-;; this gets called when we do lsp-describe-thing-at-point
-;; see lsp-methods.el. As always, remove Microsoft's unwanted entities :(
-(setq lsp-render-markdown-markup-content #'lsp-python-ms--filter-nbsp)
-
-;; lsp-ui-doc--extract gets called when hover docs are requested
-;; as always, we have to remove Microsoft's unnecessary &nbsp; entities
-(advice-add 'lsp-ui-doc--extract
-            :filter-return #'lsp-python-ms--filter-nbsp)
-
-;; lsp-ui-sideline--format-info gets called when lsp-ui wants to show
-;; hover info in the sideline again &nbsp; has to be removed
-(advice-add 'lsp-ui-sideline--format-info
-            :filter-return #'lsp-python-ms--filter-nbsp)
-
 (defun lsp-python-ms--report-progress-callback (_workspace params)
   "Log progress information."
   (when (and (arrayp params) (> (length params) 0))
@@ -414,38 +400,55 @@ WORKSPACE is just used for logging and _PARAMS is unused."
           (lsp--spinner-stop))))
     (lsp--info "Microsoft Python language server is analyzing...done")))
 
-(lsp-register-custom-settings
- `(("python.autoComplete.addBrackets" lsp-python-ms-completion-add-brackets)
-   ("python.analysis.cachingLevel" lsp-python-ms-cache)
-   ("python.analysis.errors" lsp-python-ms-errors)
-   ("python.analysis.warnings" lsp-python-ms-warnings)
-   ("python.analysis.information" lsp-python-ms-information)
-   ("python.analysis.disabled" lsp-python-ms-disabled)
-   ("python.analysis.autoSearchPaths" (lambda () (<= (length lsp-python-ms-extra-paths) 0)) t)
-   ("python.autoComplete.extraPaths" lsp-python-ms-extra-paths)))
+;;;###autoload
+(defun lsp-python-ms-initialize ()
+  "Initialize `lsp-python-ms'."
+  ;; this gets called when we do lsp-describe-thing-at-point
+  ;; see lsp-methods.el. As always, remove Microsoft's unwanted entities :(
+  (setq lsp-render-markdown-markup-content #'lsp-python-ms--filter-nbsp)
 
-(dolist (mode lsp-python-ms-extra-major-modes)
-  (add-to-list 'lsp-language-id-configuration `(,mode . "python")))
+  ;; lsp-ui-doc--extract gets called when hover docs are requested
+  ;; as always, we have to remove Microsoft's unnecessary &nbsp; entities
+  (advice-add 'lsp-ui-doc--extract
+              :filter-return #'lsp-python-ms--filter-nbsp)
 
-(lsp-register-client
- (make-lsp-client
-  :new-connection (lsp-stdio-connection (lambda () lsp-python-ms-executable)
-                                        (lambda () (f-exists? lsp-python-ms-executable)))
-  :major-modes (append '(python-mode) lsp-python-ms-extra-major-modes)
-  :server-id 'mspyls
-  :priority 1
-  :initialization-options 'lsp-python-ms--extra-init-params
-  :notification-handlers (lsp-ht ("python/languageServerStarted" 'lsp-python-ms--language-server-started-callback)
-                                 ("telemetry/event" 'ignore)
-                                 ("python/reportProgress" 'lsp-python-ms--report-progress-callback)
-                                 ("python/beginProgress" 'lsp-python-ms--begin-progress-callback)
-                                 ("python/endProgress" 'lsp-python-ms--end-progress-callback))
-  :initialized-fn (lambda (workspace)
-                    (with-lsp-workspace workspace
-                      (lsp--set-configuration (lsp-configuration-section "python"))))
-  :download-server-fn (lambda (client callback error-callback update?)
-                        (when lsp-python-ms-auto-install-server
-                          (lsp-python-ms--install-server client callback error-callback update?)))))
+  ;; lsp-ui-sideline--format-info gets called when lsp-ui wants to show
+  ;; hover info in the sideline again &nbsp; has to be removed
+  (advice-add 'lsp-ui-sideline--format-info
+              :filter-return #'lsp-python-ms--filter-nbsp)
+
+  (lsp-register-custom-settings
+   `(("python.autoComplete.addBrackets" lsp-python-ms-completion-add-brackets)
+     ("python.analysis.cachingLevel" lsp-python-ms-cache)
+     ("python.analysis.errors" lsp-python-ms-errors)
+     ("python.analysis.warnings" lsp-python-ms-warnings)
+     ("python.analysis.information" lsp-python-ms-information)
+     ("python.analysis.disabled" lsp-python-ms-disabled)
+     ("python.analysis.autoSearchPaths" (lambda () (<= (length lsp-python-ms-extra-paths) 0)) t)
+     ("python.autoComplete.extraPaths" lsp-python-ms-extra-paths)))
+
+  (dolist (mode lsp-python-ms-extra-major-modes)
+    (add-to-list 'lsp-language-id-configuration `(,mode . "python")))
+
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection (lambda () lsp-python-ms-executable)
+                                          (lambda () (f-exists? lsp-python-ms-executable)))
+    :major-modes (append '(python-mode) lsp-python-ms-extra-major-modes)
+    :server-id 'mspyls
+    :priority 1
+    :initialization-options 'lsp-python-ms--extra-init-params
+    :notification-handlers (lsp-ht ("python/languageServerStarted" 'lsp-python-ms--language-server-started-callback)
+                                   ("telemetry/event" 'ignore)
+                                   ("python/reportProgress" 'lsp-python-ms--report-progress-callback)
+                                   ("python/beginProgress" 'lsp-python-ms--begin-progress-callback)
+                                   ("python/endProgress" 'lsp-python-ms--end-progress-callback))
+    :initialized-fn (lambda (workspace)
+                      (with-lsp-workspace workspace
+                        (lsp--set-configuration (lsp-configuration-section "python"))))
+    :download-server-fn (lambda (client callback error-callback update?)
+                          (when lsp-python-ms-auto-install-server
+                            (lsp-python-ms--install-server client callback error-callback update?))))))
 
 (provide 'lsp-python-ms)
 


### PR DESCRIPTION
Hi.
First, very thank you for develop/maintain such a many and
greatest lsp packages.

As I found this package is not confirm Elisp convention, I fix it.

The convention is below statement.
[Emacs Lisp Coding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html)
```
Simply loading a package should not change Emacs's editing
behavior. Include a command or commands to enable and disable the
feature, or to invoke it.

This convention is mandatory for any file that includes custom
definitions. If fixing such a file to follow this convention
requires an incompatible change, go ahead and make the
incompatible change; don't postpone it.
```

So, I remove toplevel sexps and wrap them with *-initialize funciton.
It's true this PR break users init.el, but this is needed for
confirm Elisp coding convention.
(The user actions required by this change can be found by
referring to the changes in the README.)