### PR TITLE
Add more robust mechanism for finding python environments

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -300,7 +300,8 @@ After stopping or killing the process, retry to update."
                                                    (expand-file-name file (locate-dominating-file path file))))
                                 yamls))
               (dominating-yaml-file (car (seq-filter (lambda (file) file) dominating-yaml)))
-              (dominating-conda-name (conda--get-name-from-env-yml dominating-yaml-file))
+              (dominating-conda-name (or (bound-and-true-p conda-env-current-name)
+                                         (conda--get-name-from-env-yml dominating-yaml-file)))
               (dominating-conda-python (expand-file-name
                                         lsp-python-ms-python-executable-cmd
                                         (expand-file-name

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -341,7 +341,7 @@ After stopping or killing the process, retry to update."
          (sys-python (executable-find lsp-python-ms-python-executable-cmd)))
     ;; pythons by preference: local pyenv version, local conda version
 
-    (if lsp-python-ms-guess env
+    (if lsp-python-ms-guess-env
       (cond
        ( (lsp-python-ms--valid-python venv-python) )
        ( (lsp-python-ms--valid-python pyenv-python) )
@@ -352,12 +352,13 @@ After stopping or killing the process, retry to update."
 ;; it's crucial that we send the correct Python version to MS PYLS,
 ;; else it returns no docs in many cases furthermore, we send the
 ;; current Python's (can be virtualenv) sys.path as searchPaths
-(defun lsp-python-ms--get-python-ver-and-syspath (workspace-root)
+(defun lsp-python-ms--get-python-ver-and-syspath (&optional workspace-root)
   "Return list with pyver-string and list of python search paths.
 
 The WORKSPACE-ROOT will be prepended to the list of python search
 paths and then the entire list will be json-encoded."
   (when-let* ((python (lsp-python-ms-locate-python))
+              (workspace-root (or workspace-root "."))
               (default-directory workspace-root)
               (init "from __future__ import print_function; import sys; \
 sys.path = list(filter(lambda p: p != '', sys.path)); import json;")

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -3,7 +3,7 @@
 ;; Author: Charl Botha
 ;; Maintainer: Andrew Christianson, Vincent Zhang
 ;; Version: 0.7.0
-;; Package-Requires: ((emacs "25.1") (cl-lib "0.6.1") (lsp-mode "6.0"))
+;; Package-Requires: ((emacs "26.1") (cl-lib "0.6.1") (lsp-mode "6.0") (conda "0.4"))
 ;; Homepage: https://github.com/andrew-christianson/lsp-python-ms
 ;; Keywords: languages tools
 
@@ -288,24 +288,24 @@ After stopping or killing the process, retry to update."
 
 (defun lsp-python-ms--dominating-conda-python (&optional dir)
   "locate dominating conda environment"
-  (let* ((path (or dir default-directory))
-         (yamls '("environment.yml"
-                  "environment.yaml"
-                  "env.yml"
-                  "env.yaml"
-                  "dev-environment.yml"
-                  "dev-environment.yaml"))
-         (dominating-yaml (seq-map
-                           (lambda (file) (if (locate-dominating-file path file)
-                                              (expand-file-name file (locate-dominating-file path file))))
-                           yamls))
-         (dominating-yaml-file (car (seq-filter (lambda (file) file) dominating-yaml)))
-         (dominating-conda-name (conda--get-name-from-env-yml dominating-yaml-file))
-         (dominating-conda-python (expand-file-name
-                                   lsp-python-ms-python-executable-cmd
-                                   (expand-file-name
-                                    conda-env-executables-dir
-                                    (conda-env-name-to-dir dominating-conda-name)))))
+  (when-let* ((path (or dir default-directory))
+              (yamls '("environment.yml"
+                       "environment.yaml"
+                       "env.yml"
+                       "env.yaml"
+                       "dev-environment.yml"
+                       "dev-environment.yaml"))
+              (dominating-yaml (seq-map
+                                (lambda (file) (if (locate-dominating-file path file)
+                                                   (expand-file-name file (locate-dominating-file path file))))
+                                yamls))
+              (dominating-yaml-file (car (seq-filter (lambda (file) file) dominating-yaml)))
+              (dominating-conda-name (conda--get-name-from-env-yml dominating-yaml-file))
+              (dominating-conda-python (expand-file-name
+                                        lsp-python-ms-python-executable-cmd
+                                        (expand-file-name
+                                         conda-env-executables-dir
+                                         (conda-env-name-to-dir dominating-conda-name)))))
     dominating-conda-python))
 
 (defun lsp-python-ms-locate-python ()

--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -308,7 +308,7 @@ After stopping or killing the process, retry to update."
               (dominating-conda-name (or (bound-and-true-p conda-env-current-name)
                                          (conda--get-name-from-env-yml dominating-yaml-file)))
               (dominating-conda-python (expand-file-name
-                                        lsp-python-ms-python-executable-cmd
+                                        (file-name-nondirectory lsp-python-ms-python-executable-cmd)
                                         (expand-file-name
                                          conda-env-executables-dir
                                          (conda-env-name-to-dir dominating-conda-name)))))


### PR DESCRIPTION
This PR makes `lsp-python-ms-locate-python` aware of conda and pyenv environments in addition to the support for project-local `venv` environments.  When an environment is located, it extracts then path to the interpreter and uses that interpreter (and thus its associated sys.path) to initialize the language server.

This has been on my daily driver branch for a while, and works well for my purposes, but I'd definitely appreciate review to insure it maps to others' use cases 