### PR TITLE
check for venv dirs sibling to parent dirs (#126)

### DIFF
--- a/lsp-python-ms.el
+++ b/lsp-python-ms.el
@@ -313,8 +313,9 @@ Only available in Emacs 27 and above."
 
 (defun lsp-python-ms--dominating-venv-python (&optional dir)
   "Look for directories that look like venvs."
-  (when-let ((dominating-venv (locate-dominating-file (or dir default-directory)
-                                                      #'lsp-python-ms--venv-python)))
+  (when-let ((dominating-venv
+              (or (locate-dominating-file (or dir default-directory) #'lsp-python-ms--venv-python)
+                  (lsp-python-ms--venv-dir (locate-dominating-file (or dir default-directory) #'lsp-python-ms--venv-dir)))))
     (lsp-python-ms--venv-python dominating-venv)))
 
 (defun lsp-python-ms--dominating-conda-python (&optional dir)


### PR DESCRIPTION
I think this resolves #126 and #122.  We check first if we're in a path inside a venv (to address the latter issue) and then check if any siblings of our parent directories are a venv.